### PR TITLE
One showstopper, three changes I need to compile under linux

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -3,6 +3,8 @@ MRuby::Gem::Specification.new('mruby-marshal') do |spec|
   spec.author = 'take-cheeze'
   spec.summary = 'Marhshal module for mruby'
 
+  spec.cxx.flags.push('-fpermissive')
+  
   add_dependency 'mruby-onig-regexp', :github => 'mattn/mruby-onig-regexp'
   add_dependency 'mruby-string-ext', :core => 'mruby-string-ext'
 end

--- a/src/marshal.cpp
+++ b/src/marshal.cpp
@@ -137,7 +137,7 @@ struct write_context : public utility {
 
   bool is_struct(mrb_value const& v) const {
     return mrb_array_p(v) and
-        mrb_const_defined_at(M, mrb_class(M, v), mrb_intern_lit(M, "__members__"));
+      mrb_const_defined_at(M, mrb_obj_value(mrb_class(M, v)), mrb_intern_lit(M, "__members__"));
   }
 
   write_context& link(int const l) {
@@ -242,7 +242,7 @@ write_context& write_context::marshal(mrb_value const& v) {
         char buf[256];
         sprintf(buf, "%.16g", mrb_float(v));
         tag<'f'>().string(buf);
-      }
+      } break;
 
       case MRB_TT_ARRAY: {
         uclass(v, M->array_class).tag<'['>().fixnum(RARRAY_LEN(v));

--- a/src/marshal.cpp
+++ b/src/marshal.cpp
@@ -533,7 +533,8 @@ mrb_value read_context::marshal() {
 
   while(RARRAY_LEN(objects) <= id)
   { mrb_ary_push(M, objects, mrb_nil_value()); }
-  RARRAY_PTR(objects)[id] = ret;
+//  RARRAY_PTR(objects)[id] = ret;
+  mrb_ary_push(M, objects, ret); 
 
   assert(not mrb_nil_p(ret));
   return ret;

--- a/src/marshal.cpp
+++ b/src/marshal.cpp
@@ -6,6 +6,7 @@
 #include <mruby/value.h>
 #include <mruby/variable.h>
 
+#include <cstring>
 #include <cassert>
 #include <cstdlib>
 #include <algorithm>


### PR DESCRIPTION
Hello. This patch fixes a bug (the lack of a break statement at line 245 of marshal.cpp) and contains three more changes that I needed to apply in order to include this gem in a recent version of mruby on linux. 

The addition of the '-fpermissive' compiler option is due to the appearance of a compilation error of the form 

<pre>
error: passing 'const mrb_value' as 'this' argument of 'mrb_value& mrb_value::operator=(const mrb_value&)' discards qualifiers
</pre>


referring to line 536 of marshal.cpp. Being not a friend at all of c++, I have no idea about the proper way to fix this error.
