### PR TITLE
Assert non-zero ptr when comparing mrb_value

### DIFF
--- a/src/marshal.cpp
+++ b/src/marshal.cpp
@@ -38,11 +38,11 @@ bool operator!=(mrb_value const& lhs, mrb_sym const sym) {
 }
 
 bool operator==(mrb_value const& lhs, mrb_value const& rhs) {
-  return mrb_cptr(lhs) == mrb_cptr(rhs) and mrb_type(lhs) == mrb_type(rhs);
+  return mrb_cptr(lhs) != 0 and mrb_cptr(lhs) == mrb_cptr(rhs) and mrb_type(lhs) == mrb_type(rhs);
 }
 
 bool operator!=(mrb_value const& lhs, mrb_value const& rhs) {
-  return mrb_type(lhs) != mrb_type(rhs) or mrb_cptr(lhs) != mrb_cptr(rhs);
+  return mrb_cptr(lhs) == 0 or mrb_type(lhs) != mrb_type(rhs) or mrb_cptr(lhs) != mrb_cptr(rhs);
 }
 
 namespace {


### PR DESCRIPTION
For some reason, mrb_cptr gives 0 in certain cases (floats) on
a wasm target, while the same script produces correct pointer
values on x86.

When both of them are 0, the write_context assumes one is
a link to the other and produces bad output. Checking one of
them is 0 is good enough to prevent this.

The following script gives output as
```ruby
class Class_B
  attr_reader   :z
  def initialize
    @z = 100.0
    @s = 235.0
  end
end

$b = Class_B.new
puts $b.z
puts Marshal.load(Marshal.dump($b)).z
```

On x86
```
100
100
```

Compiled with emscripten (wasm)
```
100
235
```

The value of `z` is stored as a link in the dump, as `mrb_cptr(s)` and `mrb_cptr(z)` are both `0`, and both values are floats. I tried to figure out the reason for this behavior, but to no avail.